### PR TITLE
Make diff functions act on bytes instead of runes.

### DIFF
--- a/diffmatchpatch/patch.go
+++ b/diffmatchpatch/patch.go
@@ -121,7 +121,7 @@ func (dmp *DiffMatchPatch) PatchMake(opt ...interface{}) []Patch {
 		text1 := opt[0].(string)
 		switch t := opt[1].(type) {
 		case string:
-			diffs := dmp.DiffMain(text1, t, true)
+			diffs := dmp.DiffMain(text1, t)
 			if len(diffs) > 2 {
 				diffs = dmp.DiffCleanupSemantic(diffs)
 				diffs = dmp.DiffCleanupEfficiency(diffs)
@@ -284,7 +284,7 @@ func (dmp *DiffMatchPatch) PatchApply(patches []Patch, text string) (string, []b
 				text = text[:startLoc] + dmp.DiffText2(aPatch.diffs) + text[startLoc+len(text1):]
 			} else {
 				// Imperfect match.  Run a diff to get a framework of equivalent indices.
-				diffs := dmp.DiffMain(text1, text2, false)
+				diffs := dmp.DiffMain(text1, text2)
 				if len(text1) > dmp.MatchMaxBits && float64(dmp.DiffLevenshtein(diffs))/float64(len(text1)) > dmp.PatchDeleteThreshold {
 					// The end points match, but the content is unacceptably bad.
 					results[x] = false

--- a/diffmatchpatch/patch_test.go
+++ b/diffmatchpatch/patch_test.go
@@ -165,9 +165,9 @@ func TestPatchMakeAndPatchToText(t *testing.T) {
 		{"Null case", "", "", nil, ""},
 		{"Text2+Text1 inputs", text2, text1, nil, "@@ -1,8 +1,7 @@\n Th\n-at\n+e\n  qui\n@@ -21,17 +21,18 @@\n jump\n-ed\n+s\n  over \n-a\n+the\n  laz\n"},
 		{"Text1+Text2 inputs", text1, text2, nil, "@@ -1,11 +1,12 @@\n Th\n-e\n+at\n  quick b\n@@ -22,18 +22,17 @@\n jump\n-s\n+ed\n  over \n-the\n+a\n  laz\n"},
-		{"Diff input", dmp.DiffMain(text1, text2, false), nil, nil, "@@ -1,11 +1,12 @@\n Th\n-e\n+at\n  quick b\n@@ -22,18 +22,17 @@\n jump\n-s\n+ed\n  over \n-the\n+a\n  laz\n"},
-		{"Text1+Diff inputs", text1, dmp.DiffMain(text1, text2, false), nil, "@@ -1,11 +1,12 @@\n Th\n-e\n+at\n  quick b\n@@ -22,18 +22,17 @@\n jump\n-s\n+ed\n  over \n-the\n+a\n  laz\n"},
-		{"Text1+Text2+Diff inputs (deprecated)", text1, text2, dmp.DiffMain(text1, text2, false), "@@ -1,11 +1,12 @@\n Th\n-e\n+at\n  quick b\n@@ -22,18 +22,17 @@\n jump\n-s\n+ed\n  over \n-the\n+a\n  laz\n"},
+		{"Diff input", dmp.DiffMain(text1, text2), nil, nil, "@@ -1,11 +1,12 @@\n Th\n-e\n+at\n  quick b\n@@ -22,18 +22,17 @@\n jump\n-s\n+ed\n  over \n-the\n+a\n  laz\n"},
+		{"Text1+Diff inputs", text1, dmp.DiffMain(text1, text2), nil, "@@ -1,11 +1,12 @@\n Th\n-e\n+at\n  quick b\n@@ -22,18 +22,17 @@\n jump\n-s\n+ed\n  over \n-the\n+a\n  laz\n"},
+		{"Text1+Text2+Diff inputs (deprecated)", text1, text2, dmp.DiffMain(text1, text2), "@@ -1,11 +1,12 @@\n Th\n-e\n+at\n  quick b\n@@ -22,18 +22,17 @@\n jump\n-s\n+ed\n  over \n-the\n+a\n  laz\n"},
 		{"Character encoding", "`1234567890-=[]\\;',./", "~!@#$%^&*()_+{}|:\"<>?", nil, "@@ -1,21 +1,21 @@\n-%601234567890-=%5B%5D%5C;',./\n+~!@#$%25%5E&*()_+%7B%7D%7C:%22%3C%3E?\n"},
 		{"Long string with repeats", strings.Repeat("abcdef", 100), strings.Repeat("abcdef", 100) + "123", nil, "@@ -573,28 +573,31 @@\n cdefabcdefabcdefabcdefabcdef\n+123\n"},
 		{"Corner case of #31 fixed by #32", "2016-09-01T03:07:14.807830741Z", "2016-09-01T03:07:15.154800781Z", nil, "@@ -15,16 +15,16 @@\n 07:1\n+5.15\n 4\n-.\n 80\n+0\n 78\n-3074\n 1Z\n"},
@@ -193,7 +193,7 @@ func TestPatchMakeAndPatchToText(t *testing.T) {
 	text1 = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ut risus et enim consectetur convallis a non ipsum. Sed nec nibh cursus, interdum libero vel."
 	text2 = "Lorem a ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ut risus et enim consectetur convallis a non ipsum. Sed nec nibh cursus, interdum liberovel."
 
-	diffs := dmp.DiffMain(text1, text2, true)
+	diffs := dmp.DiffMain(text1, text2)
 	// Additional check that the diff texts are equal to the originals even if we are using DiffMain with checklines=true #29
 	assert.Equal(t, text1, dmp.DiffText1(diffs))
 	assert.Equal(t, text2, dmp.DiffText2(diffs))

--- a/diffmatchpatch/stringutil.go
+++ b/diffmatchpatch/stringutil.go
@@ -9,6 +9,7 @@
 package diffmatchpatch
 
 import (
+	"bytes"
 	"strings"
 	"unicode/utf8"
 )
@@ -47,6 +48,21 @@ func lastIndexOf(str string, pattern string, i int) int {
 	}
 	_, size := utf8.DecodeRuneInString(str[i:])
 	return strings.LastIndex(str[:i+size], pattern)
+}
+
+// bytesIndexOf returns the index of pattern in target, starting at target[i].
+func bytesIndexOf(target, pattern []byte, i int) int {
+	if i > len(target)-1 {
+		return -1
+	}
+	if i <= 0 {
+		return bytes.Index(target, pattern)
+	}
+	ind := bytes.Index(target[i:], pattern)
+	if ind == -1 {
+		return -1
+	}
+	return ind + i
 }
 
 // runesIndexOf returns the index of pattern in target, starting at target[i].


### PR DESCRIPTION
Make diff functions act on bytes instead of runes.
Removes line-based diffing because it depends on having a 32-bit granularity diff function,
and i don't feel like fixing that right now.